### PR TITLE
Fix documentation for --no-shared-links.sql.create-tables flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To save shared links to a local SQLite3 database, set the `--shared-links.sql.dr
 
 To save shared links in a MySQL database, set the `--shared-links.sql.driver=mysql` and `--shared-links.sql.dsn=<data source name>` flag (see https://github.com/go-sql-driver/mysql#dsn-data-source-name for MySQL DNS specifications).
 
-By default, PromLens will try to auto-create the necessary tables in your MySQL database. This requires the PromLens database user to have `CREATE` permissions. To turn off automatic table creation for MySQL, set the `--no-shared-links.sql.create-tables=false` flag. If you want to create tables manually, run the following against your PromLens MySQL database:
+By default, PromLens will try to auto-create the necessary tables in your MySQL database. This requires the PromLens database user to have `CREATE` permissions. To turn off automatic table creation for MySQL, set the `--no-shared-links.sql.create-tables` flag. If you want to create tables manually, run the following against your PromLens MySQL database:
 
 ```sql
 CREATE TABLE IF NOT EXISTS link (


### PR DESCRIPTION
As per the [README](https://github.com/promlabs/promlens-public/blob/master/README.md) it should be possible to disable auto-create of the tables using the `--no-shared-links.sql.create-tables=false` cli flag. If I try to use that I get the following error (using `v0.11.1`):

```
/ # /promlens --no-shared-links.sql.create-tables=false
error parsing commandline arguments: unexpected false
promlens: error: unexpected false
```

If I just execute `/promlens --no-shared-links.sql.create-tables` it seems to work. So if I understand it correctly the behaviour is like this:

`/promlens --shared-links.sql.create-tables` --> enable auto-create of the tables (default, same as not specifying `--shared-links.sql.create-tables`)
`/promlens --no-shared-links.sql.create-tables` --> disable auto-create of the tables

Furthermore `--no-shared-links.sql.create-tables` seems a little bit counterintuitive to me. I would have expected something like `--shared-links.sql.no-create-tables` or even simpler just `--shared-links.sql.create-tables=true` / `--shared-links.sql.create-tables=false` but that's completely up to personal preference.